### PR TITLE
Fix spelling in handful of places

### DIFF
--- a/docs/faq/index.html
+++ b/docs/faq/index.html
@@ -226,7 +226,7 @@ Bill originally tried to create a preprocessor for C to augment and add new capa
 <li><code>using</code>
 
 <ul>
-<li>making everything a namespacing (similar to Pascal&rsquo;s <code>with</code> but on steroids)</li>
+<li>making everything a namespace (similar to Pascal&rsquo;s <code>with</code> but on steroids)</li>
 <li>Ability to have <a href="#is-odin-an-objective-oriented-language">subtype polymorphism</a></li>
 </ul></li>
 <li>Multiple return values</li>

--- a/docs/faq/index.html
+++ b/docs/faq/index.html
@@ -604,7 +604,7 @@ For the current backend, LLVM is used to translate code to platform specific cod
 
 <p>declares both to be a &ldquo;pointer to int&rdquo;. This is clearer and more regular. This syntax is borrowed from the Pascal family, along with using <code>^</code> to denote a pointer, as it is pointy.</p>
 
-<p>Due to the style of value declarations, the type can be omitted and inferred from the declaration. The follwoing are all equivalent:</p>
+<p>Due to the style of value declarations, the type can be omitted and inferred from the declaration. The following are all equivalent:</p>
 
 <pre><code class="language-odin">a: int = 123;
 a :    = 123;

--- a/docs/index.html
+++ b/docs/index.html
@@ -73,9 +73,9 @@
 
 <p>An overview of the Odin programming language.</p>
 
-<h3 id="frequently-asked-questsions-faq-docs-faq"><a href="/docs/faq">Frequently Asked Questsions (FAQ)</a></h3>
+<h3 id="frequently-asked-questions-faq-docs-faq"><a href="/docs/faq">Frequently Asked Questions (FAQ)</a></h3>
 
-<p>Answers to common questsions about Odin.</p>
+<p>Answers to common questions about Odin.</p>
 
 <h3 id="the-odin-wiki-https-github-com-odin-lang-odin-wiki"><a href="https://github.com/odin-lang/Odin/wiki">The Odin Wiki</a></h3>
 

--- a/docs/overview/index.html
+++ b/docs/overview/index.html
@@ -1415,7 +1415,7 @@ case:
 
 <h3 id="maps">Maps</h3>
 
-<p>A <code>map</code> maps keys to values. The zero value of a map is <code>nil</code>. A <code>nil</code> map has no keys. The built-in <code>make</code> proc returns an initialzed map using the current <a href="#context-system">context</a>, and <code>delete</code> can be used to delete a map.</p>
+<p>A <code>map</code> maps keys to values. The zero value of a map is <code>nil</code>. A <code>nil</code> map has no keys. The built-in <code>make</code> proc returns an initialized map using the current <a href="#context-system">context</a>, and <code>delete</code> can be used to delete a map.</p>
 
 <pre><code class="language-odin">m := make(map[string]int);
 defer delete(m);

--- a/docs/overview/index.html
+++ b/docs/overview/index.html
@@ -1084,7 +1084,7 @@ s: []int = fibonaccis[1:4]; // creates a slice which includes elements 1 through
 fmt.println(s); // 1, 1, 2
 </code></pre>
 
-<p>Slices are like references to arrays; they do not store any data, rather describing a section, or slice, of an underyling data.</p>
+<p>Slices are like references to arrays; they do not store any data, rather describing a section, or slice, of an underlying data.</p>
 
 <p>Internally, a slice stores a pointer to the data and an integer to store the length of the slice.</p>
 

--- a/docs/overview/index.html
+++ b/docs/overview/index.html
@@ -992,7 +992,7 @@ y: int = ---; // uses uninitialized memory
 
 <p>The <code>cstring</code> type is a c-style string value, which is zero-terminated. It is equivalent to <code>char const *</code> in C. Its primary purpose is for easy interfacing with C. Please see the <a href="#foreign-system">foreign system</a> for more information.</p>
 
-<p>A <code>cstring</code> is easily convertable to an Odin <code>string</code> however, to convert a <code>string</code> to a <code>cstring</code> it requires allocations if the value is not constant.</p>
+<p>A <code>cstring</code> is easily convertible to an Odin <code>string</code> however, to convert a <code>string</code> to a <code>cstring</code> it requires allocations if the value is not constant.</p>
 
 <pre><code class="language-odin">str:  string  = &quot;Hellope&quot;;
 cstr: cstring = &quot;Hellope&quot;; // constant literal;


### PR DESCRIPTION
I noticed a spelling error on odin-lang.org, so I ran `aspell` against all of the HTML pages. I ignored anything that looked intentional, or anything that is a widely-used alternative spelling.

PS: It looks like you have two almost-identical files: docs/overview/index.html, and overview/index.html.

(It looks like you use a system to automatically generate these pages, so feel free to ignore this PR and just make the change in the original files used to generate it.)