### PR TITLE
Add instructions on how to install Odin using Scoop

### DIFF
--- a/content/docs/install.md
+++ b/content/docs/install.md
@@ -9,7 +9,6 @@ Odin is dead-simple to get started with!
 <a href="https://github.com/odin-lang/Odin/releases" class="btn btn-outline-primary">Latest Release</a>
 <a href="/docs/nightly" class="btn btn-outline-primary">Latest Nightly Builds</a>
 
-
 ## Clone or download Odin
 
 Clone the repository (recommended, `git clone https://github.com/odin-lang/Odin`).
@@ -80,6 +79,22 @@ In addition, the following platform-specific steps are necessary:
 
 For a compiler that's in-development like Odin, things move fast. Make sure you keep your compiler up-to-date by running `git pull` and then rebuilding every now and then. (or, if you use releases, redownload and rebuild)
 
+
+## Installing from package manager
+
+### Windows
+
+Windows user can install last released version using [Scoop](https://scoop.sh/). First you need to make sure the `versions` bucket is registered with:
+
+```bash
+scoop bucket add versions
+```
+
+And once that's done you can go ahead and install Odin with:
+
+```bash
+scoop install odin
+```
 
 ## What Next?
 

--- a/content/docs/install.md
+++ b/content/docs/install.md
@@ -9,6 +9,7 @@ Odin is dead-simple to get started with!
 <a href="https://github.com/odin-lang/Odin/releases" class="btn btn-outline-primary">Latest Release</a>
 <a href="/docs/nightly" class="btn btn-outline-primary">Latest Nightly Builds</a>
 
+
 ## Clone or download Odin
 
 Clone the repository (recommended, `git clone https://github.com/odin-lang/Odin`).

--- a/content/docs/install.md
+++ b/content/docs/install.md
@@ -85,7 +85,7 @@ For a compiler that's in-development like Odin, things move fast. Make sure you 
 
 ### Windows
 
-Windows user can install last released version using [Scoop](https://scoop.sh/). First you need to make sure the `versions` bucket is registered with:
+Windows user can install latest version using [Scoop](https://scoop.sh/). First you need to make sure the `versions` bucket is registered with:
 
 ```bash
 scoop bucket add versions


### PR DESCRIPTION
Odin has been added to the _Versions_ scoop bucket, so for users that have scoop installed they can easily install the last released GH version with the command: 

```
scoop install odin
```

I've added a new section to `install.md` called `Installing from package manager`, and a `Windows` section under it. In the future, when Odin becomes available on more package managers, this section can contain instructions for each as necessary.