### PR TITLE
Sentence was missing a word

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -1821,7 +1821,7 @@ Entity :: struct {
 	orientation: quaternion128,
 }
 ```
-It can used like this:
+It can be used like this:
 ```odin
 foo :: proc(entity: ^Entity) {
 	fmt.println(entity.position.x, entity.position.y, entity.position.z)


### PR DESCRIPTION
It can used like this:
It can be used like this: