### PR TITLE
when debug example to use ODIN_DEBUG

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -2665,7 +2665,7 @@ bar := 1 if condition else 42
 
 You can also use ternary expressions with constants at compile-time:
 ```odin
-DEBUG_LOG_SIZE :: 1024 when DEBUG else 0
+DEBUG_LOG_SIZE :: 1024 when ODIN_DEBUG else 0
 ```
 
 #### If-statements with initialization


### PR DESCRIPTION
using ODIN_DEBUG instead of DEBUG to make immediately usable.