### PR TITLE
overview: add Maybe, Varargs, and touch up making-slices text

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -633,6 +633,21 @@ foo :: proc(x: int) {
 }
 ```
 
+Procedures can be variadic, taking a varying number of arguments:
+
+```odin
+sum :: proc(nums: ..int) -> (result: int) {
+	for n in nums do result += n
+	return
+}
+fmt.println(sum())              // 0
+fmt.println(sum(1, 2))          // 3
+fmt.println(sum(1, 2, 3, 4, 5)) // 15
+
+odds := []int{1, 3, 5}
+fmt.println(sum(..odds))        // 9, passing a slice as varargs
+```
+
 ### Multiple results
 A procedure in Odin can return any number of results. For example:
 ```odin

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -637,7 +637,9 @@ Procedures can be variadic, taking a varying number of arguments:
 
 ```odin
 sum :: proc(nums: ..int) -> (result: int) {
-	for n in nums do result += n
+	for n in nums {
+		result += n
+	}
 	return
 }
 fmt.println(sum())              // 0
@@ -1281,7 +1283,7 @@ d := []int{1, 2, 3}           // a slice literal, for comparison
 
 // with an explicit allocator:
 e := make([]int, 6, context.allocator)
-f := make([dynamic]int, 0, 6, context.temp_allocator)
+f := make([dynamic]int, 0, 6, context.allocator)
 ```
 
 Slices and dynamic arrays can be deleted with the built-in `delete` proc.
@@ -1290,9 +1292,9 @@ Slices and dynamic arrays can be deleted with the built-in `delete` proc.
 delete(a)
 delete(b)
 delete(c)
-// delete(c)                  // no need to clean up slice literals
-delete(e)                     // dynamic arrays remember their allocator
-// delete(f)                  // the temp allocator will reuse the space
+// delete(d)                  // no need to clean up slice literals
+delete(e)                     // slices are always deleted from context.allocator
+delete(f)                     // dynamic arrays remember their allocator
 ```
 
 **Note:** There is no automatic memory management in Odin.

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -2740,6 +2740,22 @@ defer if cond {
 }
 ```
 
+#### 'Maybe(T)'
+```odin
+halve :: proc(n: int) -> Maybe(int) {
+	if n % 2 != 0 do return nil
+	return n / 2
+}
+
+half, ok := halve(2).?
+if ok do fmt.println(half)       // 1
+half, ok = halve(3).?
+if !ok do fmt.println("3/2 isn't an int")
+
+n := halve(4).? or_else 0
+fmt.println(n)                   // 2
+```
+
 ### Attributes
 
 Attributes can be applied to different kinds of declarations to modify the compilation details or behaviour of that declaration.

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -1262,6 +1262,11 @@ Slices and dynamic arrays can be explicitly allocated with the built-in `make` p
 a := make([]int, 6)           // len(a) == 6
 b := make([dynamic]int, 6)    // len(b) == 6, cap(b) == 6
 c := make([dynamic]int, 0, 6) // len(c) == 0, cap(c) == 6
+d := []int{1, 2, 3}           // a slice literal, for comparison
+
+// with an explicit allocator:
+e := make([]int, 6, context.allocator)
+f := make([dynamic]int, 0, 6, context.temp_allocator)
 ```
 
 Slices and dynamic arrays can be deleted with the built-in `delete` proc.
@@ -1270,11 +1275,12 @@ Slices and dynamic arrays can be deleted with the built-in `delete` proc.
 delete(a)
 delete(b)
 delete(c)
+// delete(c)                  // no need to clean up slice literals
+delete(e)                     // dynamic arrays remember their allocator
+// delete(f)                  // the temp allocator will reuse the space
 ```
 
-**Note:** Slices created with `make` must be deallocated with `delete`, whereas a slice literal does not need to be deleted since it is just a slice of an underlying array.
-
-**Note:** There is not automatic memory management in Odin. Slices may not be allocated using an [allocator](#allocators).
+**Note:** There is no automatic memory management in Odin.
 
 ### Enumerations
 Enumeration types define a new type whose values consist of the ones specified. The values are ordered, for example:


### PR DESCRIPTION
1. `Maybe` shows up in the overview but isn't shown off on its own, and has been asked about a couple of times in 'beginners'.

2. The varargs syntax only shows up once in context with the `#c_vararg` directive. This adds it to Procedures/Parameters and shows off both receiving and calling procedures with varargs.

3. The "Slices may not be allocated using an allocator" language is a FAQ, and I had `make([]int, len, cap) # wrong!` in my notes from my missing that capacity was only settable for dynamic arrays.