### PR TITLE
remove stray bit_set

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -1330,8 +1330,6 @@ Foo :: enum {A, B, C}
 f: Foo
 f = .A
 
-BAR :: bit_set[Foo]{.B, .C}
-
 switch f {
 case .A:
 	fmt.println("foo")


### PR DESCRIPTION
I keep reading the overview doc line by line. bit_set is not introduced at that point and has nothing to 
with "implicit selector expressions" example anyway