### PR TITLE
Reorder/rewrite examples in enums section

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -1323,11 +1323,18 @@ If an enumeration requires a specific size, a backing integer type can be specif
 Foo :: enum u8 {A, B, C} // Foo will only be 8 bits
 ```
 
-Odin supports implicit selector expressions for enums:
-```odin
-Foo :: enum {A, B, C}
+#### Implicit Selector Expression
 
+An *implicit selector expression* is an abbreviated way to access a member of an enumeration, in a context where type inference can determine the implied type. It has the following form:
+
+```odin
+.member_name
+```
+For example:
+```odin
+Foo :: enum{A, B, C}
 f: Foo
+f = Foo.A
 f = .A
 
 switch f {
@@ -1352,22 +1359,7 @@ main :: proc() {
 }
 ```
 
-#### Implicit Selector Expression
-
-An *implicit selector expression* is an abbreviated way to access a member of an enumeration, in a context where type inference can determine the implied type. It has the following form:
-
-```odin
-.member_name
-```
-For example:
-```odin
-Direction :: enum{North, East, South, West}
-d: Direction
-d = Direction.East
-d = .East
-```
-
-**Note:** This is preferred to [`using`](#using-statement) an enumeration as `using` does pollute the current scope.
+**Note:** Implicit selector expression is preferred to [`using`](#using-statement) an enumeration as `using` does pollute the current scope.
 
 
 ### Bit sets

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -1330,8 +1330,6 @@ Foo :: enum {A, B, C}
 f: Foo
 f = .A
 
-BAR :: bit_set[Foo]{.B, .C}
-
 switch f {
 case .A:
 	fmt.println("foo")


### PR DESCRIPTION
Ok. Another attempt to make enum examples more readable.
I see few (minor) problems that I'm trying to solve:
- there are two examples/paragraphs about 'implicit selector expressions' (ok one has a switch inside so I just incorporated it into the other example)

- as I said in previous PR - bit_set is not introduced at that point and does not look related to "implicit selector expressions" example - I would just move it down to the bit_sets section. I decided to remove it (I don't want to move it myself as I'm not yet certain how they work - feel free to modify my PR or open another)

So to sum as of now the whole enums section introduces 3 new concepts (Implicit selector expressions, bit_sets, using) in rapid succession and requires a little back and forth jumping- cannot be read line by line.
