### PR TITLE
Prompt users to install llvm@11 on macOS

### DIFF
--- a/content/docs/install.md
+++ b/content/docs/install.md
@@ -39,8 +39,8 @@ The following platform-specific steps are necessary:
     * Install the latest XCode (from the App Store or the [Xcode website](https://developer.apple.com/xcode/))
     * Install XCode command-line tools `xcode-select --install`
     * Install [Homebrew](https://brew.sh/) 
-    * Install LLVM through Homebrew with: `brew install llvm`
-    * Make sure the LLVM binaries and the linker are added to your `$PATH` environmental variable
+    * Install LLVM through Homebrew with: `brew install llvm@11`
+    * Make sure the LLVM binaries and the linker are added to your `$PATH` environmental variable (see `brew info llvm@11`)
 
 - GNU/Linux and other \*Nix
     * For Linux: clang and llvm (Using your distro's packet manager)


### PR DESCRIPTION
Homebrew currently installs LLVM 15 by default, which as mentioned in the [release notes for dev-2022-11](https://github.com/odin-lang/Odin/releases/tag/dev-2022-11) does not work yet.

To my great shame I missed that fact when downloading the macOS binaries and spent about an hour figuring out why `odin run hello.odin -file` was complaining about missing libraries under LLVM 15:

```
dyld[96737]: Library not loaded: /usr/local/opt/z3/lib/libz3.4.11.dylib
  Referenced from: <D8407A25-548D-3E6A-8EFD-3D4A8FA38EF6> /usr/local/Cellar/llvm/15.0.5/lib/libLLVM.dylib
  Reason: tried: '/usr/local/opt/z3/lib/libz3.4.11.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/opt/z3/lib/libz3.4.11.dylib' (no such file), '/usr/local/opt/z3/lib/libz3.4.11.dylib' (no such file), '/usr/local/lib/libz3.4.11.dylib' (no such file), '/usr/lib/libz3.4.11.dylib' (no such file, not in dyld cache), '/usr/local/Cellar/z3/4.11.2/lib/libz3.4.11.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/Cellar/z3/4.11.2/lib/libz3.4.11.dylib' (no such file), '/usr/local/Cellar/z3/4.11.2/lib/libz3.4.11.dylib' (no such file), '/usr/local/lib/libz3.4.11.dylib' (no such file), '/usr/lib/libz3.4.11.dylib' (no such file, not in dyld cache)
```

So I'm submitting this in case it saves other macOS users from the same fate, or at least to help surface that error in search engines so others might find this faster than I did.