### PR TITLE
Fix attributes link 404 in “Binding to C” news update

### DIFF
--- a/content/news/binding-to-c.md
+++ b/content/news/binding-to-c.md
@@ -67,7 +67,7 @@ Note that the procedure declaration has to end in `---` inside the `foreign` blo
 
 Odin supports multiple ways of making binding to C easier.
 
-By default, the foreign block links to a function of the same name as the name you specify inside the `foreign` block. This can be explicitly changed by using the `@(link_name=<string>)` and `@(link_prefix=<string>)` [attributes](Attributes-and-Tags). The following are all equivalent:
+By default, the foreign block links to a function of the same name as the name you specify inside the `foreign` block. This can be explicitly changed by using the `@(link_name=<string>)` and `@(link_prefix=<string>)` [attributes](https://odin-lang.org/docs/overview/#linking-and-foreign-attributes). The following are all equivalent:
 
 ```odin
 foreign foo {


### PR DESCRIPTION
Fixes the 404 for the 'attributes' link at https://odin-lang.org/news/binding-to-c/#foreign-blocks.