### PR TITLE
Reword a statement for clarity (Record Memory Layout)

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -2969,7 +2969,7 @@ Directives a way of extending the core behaviour of the Odin programming languag
 
 * **#packed**
 
-This tag can be applied to struct. It's field will remain in source-order.
+This tag can be applied to struct. Its fields will remain in source-order.
 ```odin
 struct #packed {x: u8, y: i32, z: u16, w: u8}
 ```
@@ -2982,7 +2982,7 @@ struct #raw_union {u: u32, i: i32, f: f32}
 ```
 
 * **#align**
-This tag can be applied to a struct or union. This tag in form `#align N` specifies the struct's alignment to N bytes. It's field will remain in source-order.
+This tag can be applied to a struct or union. This tag in form `#align N` specifies the struct's alignment to N bytes. Its fields will remain in source-order.
 ```odin
 Foo :: struct #align 4 {
     b: bool,

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -2969,7 +2969,7 @@ Directives a way of extending the core behaviour of the Odin programming languag
 
 * **#packed**
 
-This tag can be applied to struct. By doing so, the Odin compiler will omit padding and preserve the order of fields in a struct.
+This tag can be applied to struct. It's field will remain in source-order.
 ```odin
 struct #packed {x: u8, y: i32, z: u16, w: u8}
 ```
@@ -2982,7 +2982,7 @@ struct #raw_union {u: u32, i: i32, f: f32}
 ```
 
 * **#align**
-This tag can be applied to a struct or union. This tag in form `#align N` specifies the struct's alignment to N bytes.
+This tag can be applied to a struct or union. This tag in form `#align N` specifies the struct's alignment to N bytes. It's field will remain in source-order.
 ```odin
 Foo :: struct #align 4 {
     b: bool,


### PR DESCRIPTION
"By doing so" made it sound like that the next statement (that it kept the fields in source order) was special, when it actually wasn't.