### PR TITLE
Fixed two typos in Odin overview docs.

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -1056,7 +1056,7 @@ The exception to these rules are when the dividend `x` is the most non-negative 
 
 If the divisor is a constant, it must not be zero. If the divisor is zero at runtime, a runtime panic occurs.
 
-The shift operators shift the left operand by the shift count specified by the right operand, which must be non-negative. The shift operators implement arithmetic shifts if the left operand a signed integer and logical shifts if the it is an unsigned integer. There is not an upper limit on the shift count. Shifts behave as if the left operand is shifted `n` times by `1` for a shift count of `n`. Therefore, `x<<1` is the same as `x*2` and `x>>1` is the same as `x/2` but truncated towards negative infinity.
+The shift operators shift the left operand by the shift count specified by the right operand, which must be non-negative. The shift operators implement arithmetic shifts if the left operand is a signed integer and logical shifts if the left operand is an unsigned integer. There is not an upper limit on the shift count. Shifts behave as if the left operand is shifted `n` times by `1` for a shift count of `n`. Therefore, `x<<1` is the same as `x*2` and `x>>1` is the same as `x/2` but truncated towards negative infinity.
 
 ```
 x << y         is "x << y if y < 8*size_of(x) else 0"


### PR DESCRIPTION
I found two small typos in the description of the shift operator in Odin's overview doc page.

There was a missing "is" for the signed integer shift part and the unsigned integer shift part said "the it" when "it" was likely intended. 

However, "it" is grammatically ambiguous here so I further changed "it" to be "the left operand" also instead, so that the sentence is no longer ambiguous.