### PR TITLE
Example code for `bit_set` used deprecated `..` op.

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -1412,7 +1412,7 @@ Direction :: enum{North, East, South, West}
 
 Direction_Set :: bit_set[Direction]
 
-Char_Set :: bit_set['A'..'Z']
+Char_Set :: bit_set['A'..='Z']
 
 Number_Set :: bit_set[0..<10] // bit_set[0..=9]
 ```


### PR DESCRIPTION
When I ran the code for this `bit_set` declaration the compiler gave me a syntax deprecation warning saying that `..` has been deprecated.

Furthermore, the syntax error message it gave me itself **also** had a (separate, different) typo in it. See:

```
Syntax Warning: '..' for ranges has now be deprecated, prefer '..='
```

Notice that it says "has now be". I think it should instead be "has been".

I haven't even finished reading the Overview docs yet though, so I think I should leave changing the syntax error text to someone else. So, feel free to do that.