### PR TITLE
Fixed another use of deprecated `..` op.

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -1412,7 +1412,7 @@ Direction :: enum{North, East, South, West}
 
 Direction_Set :: bit_set[Direction]
 
-Char_Set :: bit_set['A'..'Z']
+Char_Set :: bit_set['A'..='Z']
 
 Number_Set :: bit_set[0..<10] // bit_set[0..=9]
 ```


### PR DESCRIPTION
I found another use of deprecated `..` op and changed it to `..=`.

This is the same kind of error as my most recent pull request.