### PR TITLE
Fixed typo in the definition of the `&` operator.

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -1468,7 +1468,7 @@ Odin has pointers. A pointer is a memory address of a value. The type `^T` is a 
 ```odin
 p: ^int
 ```
-The `&` operator takes the address to its operand (if possible):
+The `&` operator takes the address of its operand (if possible):
 ```odin
 i := 123;
 p := &i;


### PR DESCRIPTION
`the address to its operand` should be `the address of its operand`.