### PR TITLE
Fixed lack of bold on "Note:" in parapoly section.

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -2494,7 +2494,7 @@ link_prefix=<string>
 ## Parametric polymorphism
 Parametric polymorphism, commonly referred to as "generics", allow the user to create a procedure or data that can be written _generically_ so it can handle values in the same manner.
 
-Note: Within the Odin code base and documentation, the nickname "parapoly" is usually used.
+**Note:** Within the Odin code base and documentation, the nickname "parapoly" is usually used.
 
 ### Explicit parametric polymorphism
 Explicit parametric polymorphism means that the types of the parameters must be explicitly provided.


### PR DESCRIPTION
The lack of bold here is inconsistent with the style of other instances of "Note:" in the docs.