### PR TITLE
Updated copyright year range for the Odin site.

### DIFF
--- a/themes/odin/layouts/partials/footer.html
+++ b/themes/odin/layouts/partials/footer.html
@@ -46,7 +46,7 @@
             </nav>
         </div>
 
-        <div class="mt-4 text-muted">© 2016–2022 Ginger Bill</div>
+        <div class="mt-4 text-muted">© 2016–2023 Ginger Bill</div>
     </div>
 </footer>
 


### PR DESCRIPTION
When looking at the website, I randomly noticed that the copyright year number for Odin for Ginger Bill was still "2016-2022".

Thus, I found this footer HTML file and edited it here.

Is this the correct way to fix that for the site? Should I be fixing it?

In any case, I thought you should know, and so I'm submitting this proposed change.