### PR TITLE
Attributes and directives section update

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -3116,7 +3116,7 @@ proc_without_bounds_check :: proc() #no_bounds_check {
 }
 ```
 
-### Built-in directives
+### Built-in procedures
 
 #### `#assert(<boolean>)`
 


### PR DESCRIPTION
- Moved attributes and directives sections out of the idioms section
- Changed attributes and directives into headers vs bold list items
- Added `@(extra_linker_flags=<string>)` attribute
- Added `@(optimization_mode=<string>)` attribute