### PR TITLE
Add overview docs for cli and tests

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -3868,11 +3868,11 @@ test_that_hello_world_equals :: proc(t: ^testing.T) {
 }
 ```
 
-You can run this test using `odin test tests/`. Any tests in the given directory that are annotated with `@test` will be run. You can also run a single test file using `odin test tests/test_code.odin -file`.
+You can run this test using `odin test tests/`. Any procedures in the given directory that are annotated with `@test` will be run. You can also run a single test file using `odin test tests/test_code.odin -file`.
 
 You may also use the [`_test` file suffix](#file-suffixes) to only include a file in the build when testing. e.g: `foo_test.odin`. Just like other file suffixes, this means that the file will only be analyzed when you are running `odin test`.
 
-If you'd like to refer to good example tests, see [Odin/tests](https://github.com/odin-lang/Odin/tree/master/tests) and [ols/tests](https://github.com/DanielGavin/ols/tree/master/tests).
+If you'd like to refer to good example tests, see [Odin/tests](https://github.com/odin-lang/Odin/tree/master/tests). The [unofficial language server](https://github.com/DanielGavin/ols/tree/master/tests) also has tests which could be could be worth a look.
 
 ### Advanced idioms
 

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -2663,9 +2663,9 @@ A couple of ways are provided for doing this, and each of them have their uses.
 
 Often, you want to separate multiple implementations of a package based on the OS or the architecture.
 
-Your .odin files can have a magic suffix that will cause the compiler to either include or exclude them based on the target platform or architecture, or both.
+Your `.odin` files can have a magic suffix that will cause the compiler to either include or exclude them based on the target platform or architecture, or both.
 
-For example, `foobar_windows.odin` would only be compiled on Windows, `foobar_linux.odin` only on Linux, and `foobar_windows_amd64.odin` only on Windows AMD64.
+For example, `foobar_windows.odin` would only be compiled on Windows, `foobar_linux.odin` only on Linux, `foobar_windows_amd64.odin` only on Windows AMD64, and `foobar_test.odin` only runs during testing.
 
 ### `when` statements
 
@@ -2761,7 +2761,8 @@ You can read up further on [Built-in procedures](#configidentifer-default) here.
 This feature allows you to cover more edge-case situations where you want some code to be compiled on several platforms.
 
 However, overly-liberal use of this feature can make it hard to reason about what code is included or not, based on the target platform or architecture.
-[File Suffixes](#File-Suffixes) are typically a nicer approach if they cover what you need.
+
+[File suffixes](#file-suffixes) are typically a nicer approach if they cover what you need.
 
 For the sake of demonstration, let's take POSIX: You could use `foobar_unix.odin`, which has no special meaning to the compiler at all, and use a tag in the file itself.
 
@@ -3869,7 +3870,7 @@ test_that_hello_world_equals :: proc(t: ^testing.T) {
 
 You can run this test using `odin test tests/`. Any tests in the given directory that are annotated with `@test` will be run. You can also run a single test file using `odin test tests/test_code.odin -file`.
 
-**Note:** Odin files ending in `_test.odin` are only compiled when building/running tests with `odin test`. Your test files are not required to have this filename suffix to run with `odin test`, but you can use it to prevent code from building included during normal `odin build` or `odin run` commands. This filename suffix is similar to `_windows.odin` files, which will only be compiled if the target OS is Windows.
+You may also use the [`_test` file suffix](#file-suffixes) to only include a file in the build when testing. e.g: `foo_test.odin`. Just like other file suffixes, this means that the file will only be analyzed when you are running `odin test`.
 
 If you'd like to refer to good example tests, see [Odin/tests](https://github.com/odin-lang/Odin/tree/master/tests) and [ols/tests](https://github.com/DanielGavin/ols/tree/master/tests).
 

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -35,6 +35,42 @@ Odin thinks in terms of directory-based packages. To tell it to treat a single f
 odin run hellope.odin -file
 ```
 
+### Command Line Help
+
+For most `odin` subcommands, you can use the `--help` flag after the subcommand for more details:
+
+```
+> odin test --help
+
+odin is a tool for managing Odin source code
+Usage:
+    odin test [arguments]
+
+    test      Build and runs procedures with the attribute @(test) in the initial package
+
+    Flags
+
+	# ...
+```
+
+Or:
+```
+> odin check --help
+odin is a tool for managing Odin source code
+Usage:
+    odin check [arguments]
+
+    check   Parse and type check directory of .odin files
+        Examples:
+            odin check .                    # Type check package in current directory
+            odin check <dir>                # Type check package in <dir>
+            odin check filename.odin -file  # Type check single-file package, must contain entry point.
+
+    Flags
+
+	# ...
+```
+
 ## Lexical elements and literals
 ### Comments
 Comments can be anywhere outside of a string or character literal. Single line comments begin with `//`:
@@ -3806,6 +3842,36 @@ if !ok do fmt.println("3/2 isn't an int")
 n := halve(4).? or_else 0
 fmt.println(n)                   // 2
 ```
+
+#### Testing
+
+Odin includes [a "core:testing" package](https://pkg.odin-lang.org/core/testing/) for unit testing purposes.
+
+A minimalist example test:
+
+```odin
+// tests/test_code.odin
+
+package test_code
+
+import "core:testing"
+
+@test
+test_that_hello_world_equals :: proc(t: ^testing.T) {
+	expected := "Hello, World!"
+
+	// More likely this is a call to a function you want to test
+	result := "Goodbye, Mars!"
+
+	testing.expect_value(t, result, expected)
+}
+```
+
+You can run this test using `odin test tests/`. Any tests in the given directory that are annotated with `@test` will be run. You can also run a single test file using `odin test tests/test_code.odin -file`.
+
+**Note:** Odin files ending in `_test.odin` are only compiled when building/running tests with `odin test`. Your test files are not required to have this filename suffix to run with `odin test`, but you can use it to prevent code from building included during normal `odin build` or `odin run` commands. This filename suffix is similar to `_windows.odin` files, which will only be compiled if the target OS is Windows.
+
+If you'd like to refer to good example tests, see [Odin/tests](https://github.com/odin-lang/Odin/tree/master/tests) and [ols/tests](https://github.com/DanielGavin/ols/tree/master/tests).
 
 ### Advanced idioms
 


### PR DESCRIPTION
There was [a conversation in the Discord about some weird behavior](https://discord.com/channels/568138951836172421/568871298428698645/1157499252440830022) where Odin files ending in `_test.odin` aren't compiled unless you are running `odin test`. In my case, I had a file named `generate_test.odin` that was normal application code that generated tests, and this file was being ignored by `odin build` and `odin check`. Once I renamed the file to not end in `_test.odin`, things worked fine.

Then I noticed that there actually was no mention of unit tests in the overview, so I added that and added a note about the `_test.odin` thing at the end of the new section.

I also opted to add a note about the `--help` flag for Odin subcommands. 😄 