### PR TITLE
fix mistake overview.md

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -288,7 +288,7 @@ for i in 0..=9 {
 	fmt.println(i)
 }
 ```
-where `a..=b` denotes a closed interval `[a,b]`, i.e. the upper limit is *inclusive*, and `a..<b` denotes a half-open interval `[a,b]`, i.e. the upper limit is *exclusive*.
+where `a..=b` denotes a closed interval `[a,b]`, i.e. the upper limit is *inclusive*, and `a..<b` denotes a half-open interval `[a,b)`, i.e. the upper limit is *exclusive*.
 
 Certain built-in types can be iterated over:
 ```odin


### PR DESCRIPTION
I found a small mistake.
The docs gives the interval notation [a,b] and says the upper limit is exclusive. I think it should be [a,b).

BTW grate language.