### PR TITLE
Fixed typo in faq.md

### DIFF
--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -295,7 +295,7 @@ ptr: ^int = new(int)
 free(ptr)
 ```
 
-`delete` deinitializes the the slice, dynamic array, map, and string types.
+`delete` deinitializes the slice, dynamic array, map, and string types.
 ```odin
 slice := make([]int, 10)
 delete(slice)


### PR DESCRIPTION
Fixed doubled 'the' typo in _What is the difference between free and delete?_:

delete deinitializes the **the** slice, dynamic array, map, and string types.