### PR TITLE
Remove gendered language

### DIFF
--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -262,7 +262,7 @@ The same reason why strings and dynamic arrays are: they are such a useful, powe
 
 In each scope, there is an implicit value named `context`. This `context` variable is local to each scope and is implicitly passed by pointer to any procedure call in that scope (if the procedure has the Odin calling convention).
 
-The main purpose of the implicit context system is for the ability to intercept third-party code and libraries and modify their functionality. One such case is modifying how a library allocates something or logs something. In C, this was usually achieved with the library defining macros which could be overridden so that the user could define what he wanted. However, not many libraries supported this in many languages by default which meant intercepting third-party code to see what it does and to change how it does it is not possible.
+The main purpose of the implicit context system is for the ability to intercept third-party code and libraries and modify their functionality. One such case is modifying how a library allocates something or logs something. In C, this was usually achieved with the library defining macros which could be overridden so that the user could define what they wanted. However, not many libraries supported this in many languages by default which meant intercepting third-party code to see what it does and to change how it does it is not possible.
 
 Please see the overview section on the [implicit context system](/docs/overview/#implicit-context-system) for more information.
 
@@ -401,7 +401,7 @@ a := int(123)
 ```
 
 ### Why is there no pointer arithmetic?
-Type safety and simplicity. Due to slices being a first-class datatype, a lot of the need for pointer arithmetic is reduced. However, if you still require it, the `mem` package provides so utility functions: `mem.ptr_offset` and `mem.ptr_sub`. Odin will allow the programmer to do unsafe things if he wishes so.
+Type safety and simplicity. Due to slices being a first-class datatype, a lot of the need for pointer arithmetic is reduced. However, if you still require it, the `mem` package provides so utility functions: `mem.ptr_offset` and `mem.ptr_sub`. Odin will allow the programmer to do unsafe things if they so wish.
 
 If pointer arithmetic operations are still required and common (maybe due to interfacing with foreign C-like code), [multi-pointers](https://odin-lang.org/docs/overview/#multi-pointers) may be a better option to use.
 

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -2780,7 +2780,7 @@ package foobar
 ## Implicit context system
 In each scope, there is an implicit value named `context`. This `context` variable is local to each scope and is implicitly passed by pointer to any procedure call in that scope (if the procedure has the Odin calling convention).
 
-The main purpose of the implicit `context` system is for the ability to intercept third-party code and libraries and modify their functionality. One such case is modifying how a library allocates something or logs something. In C, this was usually achieved with the library defining macros which could be overridden so that the user could define what he wanted. However, not many libraries supported this in many languages by default which meant intercepting third-party code to see what it does and to change how it does it was not possible.
+The main purpose of the implicit `context` system is for the ability to intercept third-party code and libraries and modify their functionality. One such case is modifying how a library allocates something or logs something. In C, this was usually achieved with the library defining macros which could be overridden so that the user could define what they wanted. However, not many libraries supported this in many languages by default which meant intercepting third-party code to see what it does and to change how it does it was not possible.
 
 
 ```odin

--- a/themes/odin/layouts/partials/odin-examples/context-system.html
+++ b/themes/odin/layouts/partials/odin-examples/context-system.html
@@ -13,7 +13,7 @@ main :: proc() {
 	// functionality. One such case is modifying how a library allocates
 	// something or logs something. In C, this was usually achieved with
 	// the library defining macros which could be overridden so that the
-	// user could define what he wanted. However, not many libraries
+	// user could define what they wanted. However, not many libraries
 	// supported this in many languages by default which meant intercepting
 	// third-party code to see what it does and to change how it does it is
 	// not possible.


### PR DESCRIPTION
There are a few sentences on Odin's site which are worded in a way that assumes all users/programmers are a specific gender, which should be avoided.

The first C.A.R Hoarse quote on the FAQ page also uses similar gendered language. It feels irresponsible to alter/paraphrase it so I've left it unaltered for now, but I still want to bring attention to it to invite more input about how best to handle it.