### PR TITLE
Update overview.md

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -1888,20 +1888,21 @@ s2, ok := v.(string)
 ```
 
 #### Type switch statement
-A type switch is a construct that allows several type assertions in series. A type switch is like a regular switch statement, but the cases are types (not values). For a union, the only case types allowed are that of the union.
+A type switch is a construct that allows several type assertions in series. A type switch is like a regular switch statement, but the cases are not values, but types of a value. For a union, the only case types allowed are that of the union.
 ```odin
-value: Value = ...
-switch v in value {
-case string:
-	#assert(type_of(v) == string)
+v: Value = ...
+switch val in v {
 
 case bool:
-	#assert(type_of(v) == bool)
+	#assert(type_of(val) == bool)
+
+case string:
+	fmt.println(val, "is a string!")
 
 case i32, f32:
 	// This case allows for multiple types, therefore we cannot know which type to use
-	// `v` remains the original union value
-	#assert(type_of(v) == Value)
+	// `val` remains the original union value
+	#assert(type_of(val) == Value)
 case:
 	// Default case
 	// In this case, it is `nil`


### PR DESCRIPTION
I aim to make the "type switches" section clearer to a newbie.

As it stands:
Variable 'v' changes types in a messy way:
'union' chapter uses: 'v := Value'
'type switches' then uses: 'value := Value' and 'switch v in value'. 
Then in the #no-nil tag, the v jumps back to "v := Value". 
In two instances, 'v' is an instance of Value. In the third one, it's not an instance of Value, but actually value of an instance of Value. The type discrepancy can be confusing, so I unified the types.

It's also not 100% clear what exactly the "v" even is in the type switches section. The description spoke about "types, not values", which may make it look like "v" is a type representation when it's actually value.
So I:
- specified in the description that the switch searches for types of a value, not just types
- used a more descriptive "val" name instead of "v" 
- replaced one of the asserts with a fmt.println. Assert is a compile time instruction and provides no useful information here. If I was to copy paste the code to learn from it, I receive no visual feedback. fmt.println will give immediate visual feedback on what exactly "val" means when it is a string.