### PR TITLE
Document labeled block `break`

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -600,6 +600,13 @@ loop: for cond1 {
 		break loop // leaves both loops
 	}
 }
+
+exit: {
+    if true {
+        break exit // works with labeled blocks too
+    }
+    fmt.println("This line will never print.")
+}
 ```
 
 #### `continue` statement


### PR DESCRIPTION
I figured it helped to make this explicit. Even though the explanation says "labeled construct," it might not be as clear that you can do this with a plain block.