### PR TITLE
Update install instructions to include LLVM 18 as an acceptable version

### DIFF
--- a/content/docs/install.md
+++ b/content/docs/install.md
@@ -43,7 +43,7 @@ The following platform-specific steps are necessary:
     * Make sure the LLVM binaries and the linker are added to your `$PATH` environmental variable (see `brew info llvm@14`)
 
 - GNU/Linux and other \*Nix
-    * For Linux: clang and llvm (version 11.1, 12, 13, 14 or 17; using your distro's package manager)
+    * For Linux: clang and llvm (version 11.1, 12, 13, 14, 17, or 18; using your distro's package manager)
     * Note: If an atomic.h error occurs, also add `libx32stdc++-12-dev`
     * For FreeBSD: `pkg install bash git llvm14`
     * Make sure the LLVM binaries and the linker are added to your `$PATH` environmental variable


### PR DESCRIPTION
Based on the code found in `build_odin.sh`, it appears that LLVM 18 is supported:
```sh
if [ -z "$LLVM_CONFIG" ]; then
	# darwin, linux, openbsd
	if   [ -n "$(command -v llvm-config-18)" ]; then LLVM_CONFIG="llvm-config-18"
	elif [ -n "$(command -v llvm-config-17)" ]; then LLVM_CONFIG="llvm-config-17"
	elif [ -n "$(command -v llvm-config-14)" ]; then LLVM_CONFIG="llvm-config-14"
	elif [ -n "$(command -v llvm-config-13)" ]; then LLVM_CONFIG="llvm-config-13"
	elif [ -n "$(command -v llvm-config-12)" ]; then LLVM_CONFIG="llvm-config-12"
	elif [ -n "$(command -v llvm-config-11)" ]; then LLVM_CONFIG="llvm-config-11"
	# freebsd
	elif [ -n "$(command -v llvm-config18)" ]; then  LLVM_CONFIG="llvm-config18"
	elif [ -n "$(command -v llvm-config17)" ]; then  LLVM_CONFIG="llvm-config17"
	elif [ -n "$(command -v llvm-config14)" ]; then  LLVM_CONFIG="llvm-config14"
	elif [ -n "$(command -v llvm-config13)" ]; then  LLVM_CONFIG="llvm-config13"
	elif [ -n "$(command -v llvm-config12)" ]; then  LLVM_CONFIG="llvm-config12"
	elif [ -n "$(command -v llvm-config11)" ]; then  LLVM_CONFIG="llvm-config11"
	# fallback
	elif [ -n "$(command -v llvm-config)" ]; then LLVM_CONFIG="llvm-config"
	else
		error "No llvm-config command found. Set LLVM_CONFIG to proceed."
	fi
fi
```

This PR simply updates the website to reflect that.