### PR TITLE
Fix document width overflows caused by long links and tables

### DIFF
--- a/themes/odin/static/css/style.css
+++ b/themes/odin/static/css/style.css
@@ -168,6 +168,22 @@ code.hljs {
     border-radius: 0.5em;
 }
 
+/*
+prevents tables to grow beyond it's parent width
+https://stackoverflow.com/a/25296722/15597880
+*/
+.table {
+    display: block;
+    overflow-x: auto;
+}
+.table td {
+    width: 1%;
+}
+
+a {
+    word-wrap: break-word;
+}
+
 :root {
     --dark-border: #242f3f;
     --dark-background: #0d1117;


### PR DESCRIPTION
fixes #195

from https://odin-lang.org/docs/overview:

<img src="https://github.com/odin-lang/odin-lang.org/assets/24491503/2b213623-47bb-4e8f-8956-8b25c2fdcf08" width="300">

<br/><br/>

from https://odin-lang.org/news/newsletter-2024-06:

<img src="https://github.com/odin-lang/odin-lang.org/assets/24491503/3992b135-94f7-49d1-90f0-b123d5f8784b" width="300">

<br/><br/>

The weird solution with `td {width: 1%;}` is required for the table to keep taking the whole space on decktop.

Other solution would be to use media queries to only apply `table {display: block; overflow-x: auto;}` on mobile