### PR TITLE
Two octal digits are 6 bits wide.

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -93,7 +93,7 @@ If the string passed to [`len`](https://pkg.odin-lang.org/base/builtin/#len) is 
 * `\\` - backslash
 * `\"` - double quote (if needed)
 * `\'` - single quote (if needed)
-* `\NN`- octal 4 bit character (2 digits)
+* `\NN`- octal 6 bit character (2 digits)
 * `\xNN` - hexadecimal 8 bit character (2 digits)
 * `\uNNNN` - hexadecimal 16-bit Unicode character UTF-8 encoded (4 digits)
 * `\UNNNNNNNN` - hexadecimal 32-bit Unicode character UTF-8 encoded (8 digits)


### PR DESCRIPTION
Two octal digits are 6 bits wide. One octal digit (0-7) are 3 bit wide.