### PR TITLE
fix: dark mode flicker

### DIFF
--- a/themes/odin/layouts/_default/baseof.html
+++ b/themes/odin/layouts/_default/baseof.html
@@ -1,7 +1,30 @@
 <!DOCTYPE html>
 <html>
     {{- partial "head.html" . -}}
+
     <body data-bs-spy="scroll" data-bs-target="#TOC" data-bs-offset="0" tabindex="0">
+        <!-- Dark mode -->
+        <script>
+          if (!window.localStorage.getItem("theme")) {
+            if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+              window.localStorage.setItem("theme", "dark");
+              document.body.classList.add("dark-mode");
+            }
+          }
+
+          if (window.localStorage.getItem("theme") === "dark") {
+            document.body.classList.add("dark-mode");
+          }
+
+          function toggleDarkMode() {
+            if (document.body.classList.toggle("dark-mode")) {
+                window.localStorage.setItem("theme", "dark");
+            } else {
+                window.localStorage.setItem("theme", "light");
+            }
+          }
+        </script>
+
         {{- partial "header.html" . -}}
         {{- block "main" . }}{{- end }}
         {{- partial "footer.html" . -}}

--- a/themes/odin/layouts/partials/head.html
+++ b/themes/odin/layouts/partials/head.html
@@ -108,16 +108,6 @@ hljs.registerLanguage("odin", function(e) {
   gtag('config', 'UA-67516878-2');
 </script>
 
-<script>
-    function toggleDarkMode() {
-        if (document.body.classList.toggle("dark-mode")) {
-            window.localStorage.setItem("theme", "dark");
-        } else {
-            window.localStorage.setItem("theme", "light");
-        }
-    }
-</script>
-
 <!-- Custom CSS -->
 <link href="/css/style.css" rel="stylesheet" />
 

--- a/themes/odin/static/js/script.js
+++ b/themes/odin/static/js/script.js
@@ -38,14 +38,3 @@ window.addEventListener('DOMContentLoaded', () => {
 })
 
 
-if (!window.localStorage.getItem("theme")) {
-	if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
-		window.localStorage.setItem("theme", "dark");
-		document.body.classList.add("dark-mode");
-	}
-}
-
-if (window.localStorage.getItem("theme") === "dark") {
-	document.body.classList.add("dark-mode");
-}
-


### PR DESCRIPTION
Because the JS script that handles the dark mode setting (via localStorage) is located after all other content, there's a small window where the page is rendered with default theme settings.

This causes the page to flicker:

https://github.com/odin-lang/odin-lang.org/assets/18446907/85090484-6cdb-406c-9b4a-cebad8885eeb

This PR fixes this behaviour by moving the script up to the first child of the body. I've also moved the `toggleDarkMode` inside the script, so the dark mode logic is all in one place.