### PR TITLE
Fix for overview jitter when scrolling around

### DIFF
--- a/themes/odin/static/js/script.js
+++ b/themes/odin/static/js/script.js
@@ -10,7 +10,7 @@ window.addEventListener('DOMContentLoaded', () => {
 				
 				var anchor = document.querySelector(`nav li a[href="#${id}"]`);
 				anchor.parentElement.classList.add('active');
-				anchor.parentElement.scrollIntoView({ block: "nearest" });
+				anchor.parentElement.scrollIntoView({ block: "nearest", behavior: "smooth" });
 			}
 		}
 	})		


### PR DESCRIPTION
Fixes this kind of issue: https://discord.com/channels/568138951836172421/884757242220515350/1270450230537486347

The issue is within the code that automatically scrolls the table of contents. But for some reason that scrolling sometimes affects the main view, making the main view get stuck and jitter. It seems to happen when a giant section such as 'Advanced types' comes into view. That section is bigger than the vertical height of the table of contents scrollable view. I assume it then somehow tries to scroll the outer view to try to fix it.

Setting `behavior: smooth` on the `scrollIntoView` call fixes it (and also makes the automatic scrolling of the table of contents behave in a smooth cute way). Not 100% sure why it fixes it, but I assume the previous issues where some kind of single-frame-fighting issue and smoothing it out makes it stop.