### PR TITLE
Better fix for overview jitter bug

### DIFF
--- a/themes/odin/static/js/script.js
+++ b/themes/odin/static/js/script.js
@@ -10,7 +10,7 @@ window.addEventListener('DOMContentLoaded', () => {
 				
 				var anchor = document.querySelector(`nav li a[href="#${id}"]`);
 				anchor.parentElement.classList.add('active');
-				anchor.parentElement.scrollIntoView({ block: "nearest", behavior: "smooth" });
+				anchor.scrollIntoView({ block: "nearest" });
 			}
 		}
 	})		


### PR DESCRIPTION
Second fix for table-of-contents scroll jitter. Previous fix (https://github.com/odin-lang/odin-lang.org/pull/234) introduced another issue where the scroll suddenly stopped when scrolling downwards. However, I realized I can just scroll the anchor into view instead of the whole list element. The anchor is always just one row high while list element is arbitrarily big. So just scrolling to anchor stops `scrollIntoView` from getting confused. This makes the original problem go away. Removed the smooth scrolling since it caused issues.