### PR TITLE
Missing word 'sponsor' on bottom of front page.

### DIFF
--- a/themes/odin/layouts/index.html
+++ b/themes/odin/layouts/index.html
@@ -387,7 +387,7 @@
             </div>
             <br>
             <h4 class="mb-4">GitHub Sponsors</h4>
-            <p>Thank you to everyone who <a href="https://github.com/sponsors/odin-lang/" target="_blank">Odin</a>. In particular, these wonderful people sponsor Odin for $400/month or more:</p>
+            <p>Thank you to everyone who sponsor <a href="https://github.com/sponsors/odin-lang/" target="_blank">Odin</a>. In particular, these wonderful people sponsor Odin for $400/month or more:</p>
             <ul>
                 <li><a href="https://huly.io/">Huly&reg; Platform&trade;</a></li>
             </ul>


### PR DESCRIPTION
Thank you to everyone who Odin
->
Thank you to everyone who sponsor Odin