### PR TITLE
Move tracking allocator example to a subsection of allocators

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -2934,12 +2934,15 @@ Please see the procedure attribute [`@(test)`](https://odin-lang.org/docs/overvi
 
 ### `when` statements
 
-Sometimes you only want to include a small number of statements or declarations for compilation, if a certain compile-time expression evaluates
-to `true`.
-This expression can be any compile-time-known expression which results in a value of type `bool`.
+[when statements](#when-statement) are used to include or exclude code at compile-time:
 
-The compiler provides a set of builtin constants which are available in all files in a compilation, and which can be used in a `when` condition.
-Here is a comprehensive list of them:
+```
+when ODIN_OS == .Linux {
+	// Do Linux stuff
+}
+```
+
+The compiler provides a set of builtin constants which are available in all files in a compilation, and which can be used in a `when` condition. Here is a comprehensive list of them:
 
 | Name                                | Description                                                                                                                                                                             |
 |-------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -2964,7 +2967,7 @@ Here is a comprehensive list of them:
 | `ODIN_VENDOR`                       | String which identifies the compiler being used. The official compiler sets this to `"odin"`.                                                                                           |
 | `ODIN_VALGRIND_SUPPORT`             | `true` if Valgrind integration is supported on the target.                                                                                                                              |
 
-See the [tracking allocator](#tracking-allocator) for an example of something that uses the `ODIN_DEBUG` constant in a `when` block.
+See the [tracking allocator](#tracking-allocator) for an example of something that uses the `ODIN_DEBUG` constant in a `when` statement.
 
 ### Command-line defines
 

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -2934,7 +2934,7 @@ Please see the procedure attribute [`@(test)`](https://odin-lang.org/docs/overvi
 
 ### `when` statements
 
-[when statements](#when-statement) are used to include or exclude code at compile-time:
+Sometimes you only want compile a block of code if a certain compile-time expression evaluates to `true`. This can be done using the [when statements](#when-statement):
 
 ```
 when ODIN_OS == .Linux {

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -3133,7 +3133,7 @@ For more information regarding memory allocation strategies in general, please s
 
 #### Tracking allocator
 
-Odin comes with a built in tracking allocator that lets you see if your progarm is leaking memory and when it does bad frees. Here's how to set it up:
+In the core collection you'll find a tracking allocator that warns you if your progarm is leaking memory or if it does bad frees. Here's how to set it up:
 ```odin
 package main
 


### PR DESCRIPTION
Before this the tracking allocator example was waaaay down below a long list of constants in a section on the `when` statement. It was hard to link to.

Now it has its own subsection under allocators and there are some new links to find your way around.