### PR TITLE
overview.md: fixing typo of link to enumarated-array section

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -3855,7 +3855,7 @@ test :: proc() {
 }
 ```
 
-The `#partial` directive can also be used to initialize an [enumerated array](#enumeration-array).
+The `#partial` directive can also be used to initialize an [enumerated array](#enumerated-array).
 
 ### Procedure parameters
 


### PR DESCRIPTION
Simple fix. The link is currently broken.

This link may help to check it:
https://odin-lang.org/docs/overview/#enumerated-array
