### PR TITLE
Checks all cases;

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -432,7 +432,7 @@ A switch statement is another way to write a sequence of if-else statements. In 
 switch arch := ODIN_ARCH; arch {
 case .i386, .wasm32, .arm32:
 	fmt.println("32 bit")
-case .amd64, .wasm64p32, .arm64:
+case .amd64, .wasm64p32, .arm64, .riscv64:
 	fmt.println("64 bit")
 case .Unknown:
 	fmt.println("Unknown architecture")


### PR DESCRIPTION
The Overview page's first [`switch`](https://odin-lang.org/docs/overview/#switch-statement) example doesn't compile for me:

```odin
// Error: `Unhandled switch case: riscv64
//        Suggestion: Was '#partial switch' wanted?`.
switch arch := ODIN_ARCH; arch {
case .i386, .wasm32, .arm32:
	fmt.println("32-bit")
case .amd64, .wasm64p32, .arm64:
	fmt.println("64-bit")
case .Unknown:
	fmt.println("Unknown architecture")
}
```

I think this error might have been introduced via https://github.com/odin-lang/Odin/commit/ca6ef95b038f3eb443971240de73924a721485cc#diff-af3b32e62b98194a113e63df5270f8c2aa32a0ef7a003def33bf33c27d9eb335.

This PR just rolls the new `.riscv64` case into the "64 bit" group.

I'm compiling on `dev-2024-09`, on macOS.

~

```bash
$ odin version
odin version dev-2024-09:16c5c69a4
```