### PR TITLE
Add underline to inline code links

### DIFF
--- a/themes/odin/assets/scss/custom.scss
+++ b/themes/odin/assets/scss/custom.scss
@@ -66,3 +66,7 @@ $table-cell-padding-x-sm:     .2rem;
     animation-name: fade-in-navbar-logo;
     animation-duration: 1.5s;
 }
+
+.odin-article * a code {
+    text-decoration: underline;
+}


### PR DESCRIPTION
So links to things like keywords, packages, etc are more apparent. Only applies to the article, sidenav is still the same.

Example:

![inline-code-link](https://github.com/user-attachments/assets/6d256549-0a14-4852-8fef-3bb82129011b)
