### PR TITLE
improve the behaviour of section higlighting in table of contents

### DIFF
--- a/themes/odin/static/js/script.js
+++ b/themes/odin/static/js/script.js
@@ -2,7 +2,6 @@
 window.addEventListener('DOMContentLoaded', () => {
 	const headers = [...document.querySelectorAll('h1[id],h2[id],h3[id],h4[id]')];
 	const sectionVisibility = new Map();
-	headers.forEach(header => sectionVisibility.set(header.getAttribute('id'), false));
 
 	const navbarHeight = document.querySelector('.odin-menu').offsetHeight;
 	const observerForTableOfContentActiveState = new IntersectionObserver(entries => {
@@ -30,7 +29,10 @@ window.addEventListener('DOMContentLoaded', () => {
 		}
 	}, { rootMargin: `${navbarHeight}px 0px 0px 0px`, threshold: 1.0 });
 
-	headers.forEach(observerForTableOfContentActiveState.observe);
+	headers.forEach(header => {
+        sectionVisibility.set(header.getAttribute('id'), false);
+        observerForTableOfContentActiveState.observe(header);
+    });
 })
 
 // removes all active states

--- a/themes/odin/static/js/script.js
+++ b/themes/odin/static/js/script.js
@@ -1,19 +1,33 @@
 // scrollspy find any new heading intersection and set the active property
 window.addEventListener('DOMContentLoaded', () => {
+	const headers = [...document.querySelectorAll('h1[id],h2[id],h3[id],h4[id]')];
+	const sectionVisibility = new Map();
+	headers.forEach(header => sectionVisibility.set(header.getAttribute('id'), false));
+
 	const observerForTableOfContentActiveState = new IntersectionObserver(entries => {
 		for (let i = 0; i < entries.length; i += 1) {
-			var entry = entries[i];
+			const entry = entries[i];
 			const id = entry.target.getAttribute('id');
 
-			if (entry.isIntersecting) {
+			sectionVisibility.set(id, entry.isIntersecting);
+		}
+
+		/**
+		 * Find the first visible section and set the corresponding anchor state to active.
+		 * Otherwise, do nothing. This is the case when scrolling through long sections,
+		 * where the section header is out of the viewport, but the next section header is not yet visible.
+		 */
+		for (const [sectionId, isVisible] of sectionVisibility) {
+			if (isVisible) {
 				clearActiveStatesInTableOfContents();
-				
-				var anchor = document.querySelector(`nav li a[href="#${id}"]`);
+				const anchor = document.querySelector(`nav li a[href="#${sectionId}"]`);
 				anchor.parentElement.classList.add('active');
 				anchor.scrollIntoView({ block: "nearest" });
+
+				break;
 			}
 		}
-	})		
+	}, { rootMargin: '59px 0px 0px 0px', threshold: 1.0 });
 
 	document.querySelectorAll('h1[id],h2[id],h3[id],h4[id]').forEach((section) => {
 		observerForTableOfContentActiveState.observe(section);
@@ -36,5 +50,4 @@ window.addEventListener('DOMContentLoaded', () => {
 		}
 	})
 })
-
 

--- a/themes/odin/static/js/script.js
+++ b/themes/odin/static/js/script.js
@@ -4,6 +4,7 @@ window.addEventListener('DOMContentLoaded', () => {
 	const sectionVisibility = new Map();
 	headers.forEach(header => sectionVisibility.set(header.getAttribute('id'), false));
 
+	const navbarHeight = document.querySelector('.odin-menu').offsetHeight;
 	const observerForTableOfContentActiveState = new IntersectionObserver(entries => {
 		for (let i = 0; i < entries.length; i += 1) {
 			const entry = entries[i];
@@ -27,11 +28,9 @@ window.addEventListener('DOMContentLoaded', () => {
 				break;
 			}
 		}
-	}, { rootMargin: '59px 0px 0px 0px', threshold: 1.0 });
+	}, { rootMargin: `${navbarHeight}px 0px 0px 0px`, threshold: 1.0 });
 
-	document.querySelectorAll('h1[id],h2[id],h3[id],h4[id]').forEach((section) => {
-		observerForTableOfContentActiveState.observe(section);
-	});
+	headers.forEach(observerForTableOfContentActiveState.observe);
 })
 
 // removes all active states


### PR DESCRIPTION
This pull request aims to fix https://github.com/odin-lang/odin-lang.org/issues/256

Instead of changing the active section every time a new header scrolls into view the active section is only changed when the current section header scrolls out of view and a next section header is visible. 

See the attached video for comparison of the new (left) and old (right) behaviour.
[Screencast_20241111_135747.webm](https://github.com/user-attachments/assets/a4b0da94-1141-4ba4-b2ee-2699064afc85)

