### PR TITLE
fix: update hugo `min_version` and switch to `css.Sass`

### DIFF
--- a/themes/odin/layouts/partials/head.html
+++ b/themes/odin/layouts/partials/head.html
@@ -49,7 +49,7 @@
 
 <!-- Bootstrap CSS -->
 {{ $scss := resources.Get "scss/custom.scss" }}
-{{ $style := $scss | resources.ToCSS | resources.Minify }}
+{{ $style := $scss | css.Sass | resources.Minify }}
 <link rel="stylesheet" href="{{ $style.Permalink }}">
 
 <!-- Highlight.JS -->

--- a/themes/odin/theme.toml
+++ b/themes/odin/theme.toml
@@ -8,7 +8,7 @@ description = ""
 homepage = "http://example.com/"
 tags = []
 features = []
-min_version = "0.41.0"
+min_version = 0.128
 
 [author]
   name = ""


### PR DESCRIPTION
Fixes

```
ERROR deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and will be removed in Hugo 0.143.0. Use css.Sass instead.
```

by switching from `resources.ToCSS` to `css.Sass` and requiring minimum of Hugo v0.128 installed.