### PR TITLE
Fix % and %% confusion

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -1096,8 +1096,8 @@ Binary:
 -       subtraction                integers, enums, floats, complex values, quaternions, arrays of numeric types, matrices
 *       multiplication             integers, floats, complex values, quaternions, arrays of numeric types, matrices
 /       division                   integers, floats, complex values, quaternions, arrays of numeric types
-%       modulo (truncated)         integers
-%%      remainder (floored)        integers
+%       remainder (floored)        integers
+%%      modulo (truncated)         integers
 
 |       bitwise or                 integers, enums
 ~       bitwise xor                integers, enums


### PR DESCRIPTION
The docs are wrong so I corrected them. Below is my research proving docs are wrong.

in tokenizer.cpp
```cpp
    TOKEN_KIND(Token_Mod,      "%"), \
    TOKEN_KIND(Token_ModMod,   "%%"), \
```

In llvm_backend_expr.cpp:
```cpp
case Token_Mod:
    if (is_type_unsigned(integral_type)) {
        z = LLVMBuildURem(p->builder, x, y, "");
    } else {
        z = LLVMBuildSRem(p->builder, x, y, "");
    }
    break;
case Token_ModMod:
    if (is_type_unsigned(integral_type)) {
        z = LLVMBuildURem(p->builder, x, y, "");
    } else {
        LLVMValueRef a = LLVMBuildSRem(p->builder, x, y, "");
        LLVMValueRef b = LLVMBuildAdd(p->builder, a, y, "");
        z = LLVMBuildSRem(p->builder, b, y, "");
    }
    break;
```