### PR TITLE
fix memory leak in os.read_entire_file(...) example in read-a-file-line-by-line

### DIFF
--- a/content/news/read-a-file-line-by-line.md
+++ b/content/news/read-a-file-line-by-line.md
@@ -26,11 +26,11 @@ import "core:strings"
 
 read_file_by_lines_in_whole :: proc(filepath: string) {
 	data, err := os.read_entire_file(filepath, context.allocator)
+	defer delete(data, context.allocator)
 	if err != nil {
 		// could not read file
 		return
 	}
-	defer delete(data, context.allocator)
 
 	it := string(data)
 	for line in strings.split_lines_iterator(&it) {


### PR DESCRIPTION
The implementation of `os.read_entire_file` may allocate memory for a slice and then return an error, therefore we should `defer delete` the slice before we return