### PR TITLE
update gingerbill exceptions blog url

### DIFF
--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -103,7 +103,7 @@ Coupling exceptions to a control structure, as in the try-catch-finally idiom, c
 
 Odin uses plain error handling through the use of multiple return values. It is clear which procedure the error value is from compared to a `try-catch` approach which is akin to the [COMEFROM](https://en.wikipedia.org/wiki/COMEFROM) statement.
 
-Please see gingerBill's article for more information: [Exceptions — And Why Odin Will Never Have Them](https://www.gingerbill.org/article/2018/09/05/exceptions-and-why-odin-will-never-have-them/).
+Please see gingerBill's article for more information: [Exceptions — And Why Odin Will Never Have Them](https://www.gingerbill.org/article/2018/09/05/exceptions---and-why-odin-will-never-have-them/).
 
 ### Is Odin "just" a language for game development?
 


### PR DESCRIPTION
Was reading through docs/faq and noticed this blog redirect 404'd just updates to the actual live location

Existing:
`https://www.gingerbill.org/article/2018/09/05/exceptions-and-why-odin-will-never-have-them/` 
Blog location:
`https://www.gingerbill.org/article/2018/09/05/exceptions---and-why-odin-will-never-have-them/`