### PR TITLE
Fix alignment in example code

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -1821,9 +1821,9 @@ Direction :: enum{North, East, South, West}
 
 Direction_Vectors :: [Direction][2]int {
 	.North = {  0, -1 },
-	.East = { +1,  0 },
+	.East  = { +1,  0 },
 	.South = {  0, +1 },
-	.West = { -1,  0 },
+	.West  = { -1,  0 },
 }
 
 assert(Direction_Vectors[.North] == { 0, -1 })


### PR DESCRIPTION
This MR adds spaces to the example code, making the coordinate components aligned.

As there are already two spaces in front of each `0` component, I'm assuming this alignment was intended originally but somehow missed.