### PR TITLE
Mention "procedure groups" in the overview

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -844,12 +844,15 @@ Default values are assigned at the start of the procedure call and can be [overw
 **Note:** These default values must be compile time known values, such as a constant value or `nil` (if the type supports it).
 
 ### Explicit procedure overloading
-Unlike other languages, Odin provides the ability to explicitly overload procedures:
+Unlike other languages, Odin provides the ability to explicitly overload procedures using procedure groups:
 ```odin
 bool_to_string :: proc(b: bool) -> string {...}
 int_to_string  :: proc(i: int)  -> string {...}
 
-to_string :: proc{bool_to_string, int_to_string}
+to_string :: proc{
+	bool_to_string,
+	int_to_string,
+}
 ```
 
 #### Rationale behind explicit overloading


### PR DESCRIPTION
This PR mentions the term "procedure groups" in the overview to aid searching.

It came up earlier in the discord where a person new to the language was told about "procedure groups", yet the term didn't result in anything meaningful when searched for in the overview.

Also split the group into multiple lines to make it more readable.