### PR TITLE
Fix recognized ASM extension list

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -3386,7 +3386,7 @@ foreign kernel32 {
 
 The Odin compiler can also automatically build and link imported assembly files.
 Depending on the host system, [`clang`](https://clang.llvm.org/), [`as`](https://www.gnu.org/software/binutils), or [`nasm`](https://nasm.us/) may be used to compile the assembly.
-Recognized file extensions for assembly files are: `asm`, `s`, and `S`.
+Recognized file extensions for assembly files are: `asm`, `as`, and `S`.
 
 For examples of how Odin uses this feature, see `base/runtime/entry_*.asm`.
 


### PR DESCRIPTION
Hi, this seems to be a typo, so proposing a fix. I am assuming the recognized extension is `as`, I haven't checked if that's actually true.