### PR TITLE
Fix typo in The Odin Principles section

### DIFF
--- a/themes/odin/layouts/index.html
+++ b/themes/odin/layouts/index.html
@@ -154,7 +154,7 @@
                 <div class="col-lg">
                     <h3 class="fw-normal">Joy of Programming</h3>
                     <p>
-                        We go into programming because we love to solve problems. Why shouldn't our tools bring us joy whilst doing it? Enjoy programming again, with Odin!
+                        We got into programming because we love to solve problems. Why shouldn't our tools bring us joy whilst doing it? Enjoy programming again, with Odin!
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Just a small typo on the front page. "We go into programming..." --> "We got into programming"