### PR TITLE
Fix cpuid inline asm example

### DIFF
--- a/content/docs/inline-asm.md
+++ b/content/docs/inline-asm.md
@@ -367,13 +367,13 @@ rdtsc :: asm() -> (lo, hi: u32) [
 	rdtsc
 }
 
-cpuid :: asm(leaf: u32) -> (a, b, c, d: u32) [
-	leaf -> a = %eax,
-	b = %ebx,
-	c = %ecx,
-	d = %edx,
+cpuid :: asm(leaf: u32, subleaf: u32) -> (a, b, c, d: u32) [
+    leaf -> a = %eax,
+    b = %ebx,
+    subleaf -> c = %ecx,
+    d = %edx,
 ] {
-	cpuid
+    cpuid
 }
 
 // [#clobber memory] is inferred

--- a/content/docs/inline-asm.md
+++ b/content/docs/inline-asm.md
@@ -368,12 +368,12 @@ rdtsc :: asm() -> (lo, hi: u32) [
 }
 
 cpuid :: asm(leaf: u32, subleaf: u32) -> (a, b, c, d: u32) [
-    leaf -> a = %eax,
-    b = %ebx,
-    subleaf -> c = %ecx,
-    d = %edx,
+	leaf -> a = %eax,
+	b = %ebx,
+	subleaf -> c = %ecx,
+	d = %edx,
 ] {
-    cpuid
+	cpuid
 }
 
 // [#clobber memory] is inferred


### PR DESCRIPTION
Odin's inline ASM checker requires that all required operands for an instruction are provided and CPUID requires RCX pinned to some value (usually some "subleaf" value, hence the parameter name)